### PR TITLE
WH-5: Raccoons Logo Alignment

### DIFF
--- a/src/components/Footer/Footer.js
+++ b/src/components/Footer/Footer.js
@@ -33,10 +33,9 @@ const Footer = () => (
             <a href="https://www.instagram.com/wheelhouse.be/" rel="noopeener noreferrer">Instagram</a>
           </div>
         </TwoColumns>
-        <div>
-          part of
-          {' '}
-          <a className="svg" rel="noreferrer noopener" href="https://www.raccoons.be/">
+        <div className="part-of-link">
+          <p>part of</p>
+          <a rel="noreferrer noopener" href="https://www.raccoons.be/">
             <Raccoons />
           </a>
         </div>

--- a/src/components/Footer/footer.styles.js
+++ b/src/components/Footer/footer.styles.js
@@ -11,8 +11,18 @@ export const FooterContainer = styled.footer`
     display: block;
   }
 
-  .svg {
-    display: inline-block;
+  .part-of-link {
+    display: flex;
+
+    p {
+      /* Override p margins and only have some to the right */
+      margin: 0 8px 0 0;
+    }
+
+    a {
+      /* This aligns the Raccoons logo vertically */
+      line-height: 34px;
+    }
   }
 
   svg {


### PR DESCRIPTION
# ⚖️ Raccoons Logo Alignment

**OLD**
![image](https://user-images.githubusercontent.com/1874332/85377298-2ebb1f80-b539-11ea-8e83-72b1b4585e2c.png)

**NEW**
![image](https://user-images.githubusercontent.com/1874332/85377260-1ea34000-b539-11ea-916e-579d81723d5d.png)

## 🔧 Fix
I moved it into a two elements in a flexed container so I could use `line-height` to vertically center the logo to the text.